### PR TITLE
Fix /opt/jboss/docker-entrypoint.sh: [: =: unary operator expected

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ${WAIT_FOR_DB} = "true" ]; then
+if [[ ${WAIT_FOR_DB} = "true" ]]; then
     MAX=30
     TRIES=0
     DB="http://${MYSQL_PORT_3306_TCP_ADDR}:${MYSQL_PORT_3306_TCP_PORT}"


### PR DESCRIPTION
Solution based on https://github.com/fabric8io/fabric8-ipaas/issues/378 and https://stackoverflow.com/questions/13617843/unary-operator-expected